### PR TITLE
Add nil guard to Parent() for avoiding nil pointer dereference

### DIFF
--- a/factory/factory.go
+++ b/factory/factory.go
@@ -39,6 +39,9 @@ func (args *argsStruct) Instance() interface{} {
 
 // Parent returns a parent argument if current factory is a subfactory of parent
 func (args *argsStruct) Parent() Args {
+	if args.pl == nil {
+		return nil
+	}
 	return args.pl.parent
 }
 

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -246,3 +246,26 @@ func TestFactoryConstruction(t *testing.T) {
 		t.Error("user.ID should not be empty.")
 	}
 }
+
+func TestFactoryWhenCallArgsParent(t *testing.T) {
+	type User struct {
+		Name      string
+		GroupUUID string
+	}
+
+	var userFactory = NewFactory(&User{})
+	userFactory.
+		Attr("Name", func(args Args) (interface{}, error) {
+			if parent := args.Parent(); parent != nil {
+				if pUser, ok := parent.Instance().(*User); ok {
+					return pUser.GroupUUID, nil
+				}
+			}
+			return "", nil
+		})
+
+	if err := userFactory.Construct(&User{}); err != nil {
+		t.Error(err)
+		return
+	}
+}


### PR DESCRIPTION

reproduction code:

```
var userFactory = NewFactory(&User{})
userFactory.
	Attr("Name", func(args Args) (interface{}, error) {
    		if parent := args.Parent(); parent != nil { // <- `args.Parent()` will cause panic!
			// do something...
		}
		return "", nil
	})

userFactory.Construct(&User{})
```