### PR TITLE
Fix sequences not properly handling concurrency

### DIFF
--- a/factory/factory.go
+++ b/factory/factory.go
@@ -181,20 +181,20 @@ func (fa *Factory) Attr(name string, gen func(Args) (interface{}, error)) *Facto
 
 func (fa *Factory) SeqInt(name string, gen func(int) (interface{}, error)) *Factory {
 	idx := fa.checkIdx(name)
-	var seq int64 = 1
+	var seq int64 = 0
 	fa.attrGens[idx].genFunc = func(args Args) (interface{}, error) {
-		defer atomic.AddInt64(&seq, 1)
-		return gen(int(seq))
+		new := atomic.AddInt64(&seq, 1)
+		return gen(int(new))
 	}
 	return fa
 }
 
 func (fa *Factory) SeqString(name string, gen func(string) (interface{}, error)) *Factory {
 	idx := fa.checkIdx(name)
-	var seq int64 = 1
+	var seq int64 = 0
 	fa.attrGens[idx].genFunc = func(args Args) (interface{}, error) {
-		defer atomic.AddInt64(&seq, 1)
-		return gen(strconv.FormatInt(seq, 10))
+		new := atomic.AddInt64(&seq, 1)
+		return gen(strconv.FormatInt(new, 10))
 	}
 	return fa
 }


### PR DESCRIPTION
The current implementations of both `SeqInt` and `SeqString` have race conditions that cause them to potentially produce duplicate values if multiple objects are constructed concurrently.  In both functions the counter variable is incremented correctly using `atomic.AddInt64`, but the value is subsequently used in a line below with a raw read.  Instead, the result of `atomic.AddInt64` can simply be passed to the generator function, ensuring proper thread-safety.

I added a test case to reproduce this behavior, and verified that it both fails and triggers the race detector before the actual code change to the Factory type, and succeeds after.  Here is the test output before the fix: https://gist.github.com/noahgoldman/c91fd32ed7cab5a6f9997b7137ac5f37

I also added a test case to confirm that both `SeqInt` and `SeqString` start at 1 (maintaining current behavior).

